### PR TITLE
feat(meta): add favicon + social share image tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,27 @@
     <meta name="color-scheme" content="light">
     <meta name="supported-color-schemes" content="light">
     <meta name="theme-color" content="#f7f5f2">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="48x48" href="assets/favicon-48.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-48.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-48.png">
+    <link rel="shortcut icon" href="assets/favicon-48.png">
+    <link rel="apple-touch-icon" href="assets/favicon-48.png">
+
+    <!-- Open Graph (social share) -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Admiral Energy — Lower bills. Quiet backup. Solar that fits.">
+    <meta property="og:description" content="60 seconds to check fit for solar + battery. No pressure, no spam.">
+    <meta property="og:image" content="assets/share-image.png">
+    <meta property="og:url" content="/">
+    <meta property="og:site_name" content="Admiral Energy">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Admiral Energy — Lower bills. Quiet backup. Solar that fits.">
+    <meta name="twitter:description" content="60 seconds to check fit for solar + battery. No pressure, no spam.">
+    <meta name="twitter:image" content="assets/share-image.png">
     <title>Admiral Energy - Lower Bills. Quiet Backup. Solar That Fits your home.</title>
     
     <!-- Add Rubik font -->


### PR DESCRIPTION
## Summary
- add favicon links pointing to the provided 48px asset
- configure Open Graph and Twitter metadata to use the new share image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daeee6d9988326a2cdbaa9e3ac7d11