### PR TITLE
Fix: lock light mode across mobile browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Lock the document to light color scheme -->
     <meta name="color-scheme" content="light">
     <meta name="supported-color-schemes" content="light">
+
+    <!-- Ensure browser UI (address bar/status bar) uses our light palette -->
     <meta name="theme-color" content="#f7f5f2">
+
+    <!-- iOS status bar style (paired with our light background) -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <title>Admiral Energy - Lower Bills. Quiet Backup. Solar That Fits your home.</title>
     
     <!-- Add Rubik font -->
@@ -51,6 +57,54 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
+        /* Force a light-only site, including form controls */
+        :root, html, body { color-scheme: light; background: #f7f5f2; color: #0c2f4a; }
+
+        /* Important surfaces that were being auto-darkened on Android/Samsung */
+        nav,
+        .hero,
+        .hero-form,
+        .quiz-container,
+        .faq-item,
+        .trust-section,
+        .outcome-card,
+        .sticky-cta,
+        .bill-upload-container {
+            background-color: #ffffff; /* or use #f7f5f2 where appropriate */
+            color: #0c2f4a;
+        }
+
+        /* Form controls: keep them light even when OS prefers dark */
+        input, select, textarea, button {
+            background: #ffffff !important;
+            color: #0c2f4a !important;
+            border: 2px solid #e5e7eb !important;
+            -webkit-appearance: none;
+            appearance: none;
+        }
+
+        /* Autofill states can get inverted; paint them explicitly */
+        input:-webkit-autofill,
+        input:-webkit-autofill:hover,
+        input:-webkit-autofill:focus {
+            -webkit-text-fill-color: #0c2f4a;
+            -webkit-box-shadow: 0 0 0px 1000px #ffffff inset;
+                    box-shadow: 0 0 0px 1000px #ffffff inset;
+            transition: background-color 9999s ease-in-out 0s;
+        }
+
+        /* Defensive override: even if the user prefers dark, we still serve light */
+        @media (prefers-color-scheme: dark) {
+            html, body { background: #f7f5f2 !important; color: #0c2f4a !important; }
+            input, select, textarea, button {
+                background: #ffffff !important; color: #0c2f4a !important; border-color: #e5e7eb !important;
+            }
+            nav, .hero, .hero-form, .quiz-container, .faq-item, .trust-section,
+            .outcome-card, .sticky-cta, .bill-upload-container {
+                background-color: #ffffff !important; color: #0c2f4a !important;
+            }
+        }
+
         :root {
             --primary-navy: #0c2f4a;
             --accent-gold: #c9a648;
@@ -61,30 +115,12 @@
             --success-green: #10b981;
         }
 
-        :root, html, body {
-            color-scheme: light;
-            background: #f7f5f2;
-            color: #0c2f4a;
-        }
-
         body {
             font-family: 'Rubik', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', sans-serif;
             background: var(--bone-white);
             color: var(--primary-navy);
             line-height: 1.6;
             overflow-x: hidden;
-        }
-
-        input, select, textarea, button {
-            background: #ffffff;
-            color: #0c2f4a;
-            border: 2px solid #e5e7eb;
-        }
-
-        /* Force light palette even if device is in dark mode */
-        @media (prefers-color-scheme: dark) {
-            html, body { background: #f7f5f2; color: #0c2f4a; }
-            input, select, textarea, button { background: #ffffff; color: #0c2f4a; }
         }
 
         /* Animations */


### PR DESCRIPTION
## Summary
- lock the document color scheme to light in the head metadata and set light browser chrome colors
- add global CSS overrides that keep key surfaces and form controls light even when dark mode is preferred
- include defensive rules for autofill and prefers-color-scheme: dark to prevent auto inversion on mobile browsers

## Testing
- Not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68daf0a3bff08326a6413bbb2f65ff6f